### PR TITLE
Fix: focus ring on click

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -326,100 +326,50 @@ button,
 select,
 textarea {
   &:focus {
-    @include focus_BoxShadow_Small;
-    outline: 0;
-  }
-  &.focus-visible {
-    :focus:not(:focus-visible) {
-      box-shadow: none;
-      outline: 0;
-    }
-    &:focus-visible,
-    &:moz-focusring {
-      @include focus_BoxShadow_Small;
-      outline: 0;
-    }
-  }
+  @include focus_BoxShadow_Small;
+  outline: 0;
+ }
+ &.focus-visible:focus:not(:focus-visible) {
+   box-shadow: none;
+   outline: 0;
+ }
 }
 
-// a:focus {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
-// a.focus-visible:focus:not(:focus-visible) {
-//   box-shadow: none;
-//   outline: 0;
-// }
-// a.focus-visible:focus-visible,
-// a.focus-visible:moz-focusring {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
-// button:focus {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
-// button.focus-visible:focus:not(:focus-visible) {
-//   box-shadow: none;
-//   outline: 0;
-// }
-// button.focus-visible:focus-visible,
-// button.focus-visible:moz-focusring {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
+a.focus-visible:focus-visible,
+a.focus-visible:moz-focusring {
+  @include focus_BoxShadow_Small;
+  outline: 0;
+}
 
-// div:focus {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
-// div.focus-visible:focus:not(:focus-visible) {
-//   box-shadow: none;
-//   outline: 0;
-// }
-// div.focus-visible:focus-visible, div.focus-visible:moz-focusring {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
+button.focus-visible:focus-visible,
+button.focus-visible:moz-focusring {
+  @include focus_BoxShadow_Small;
+  outline: 0;
+}
 
-// input:focus {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
-// input.focus-visible:focus:not(:focus-visible) {
-//   box-shadow: none;
-//   outline: 0;
-// }
-// input.focus-visible:focus-visible, input.focus-visible:moz-focusring {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
+div.focus-visible:focus-visible,
+div.focus-visible:moz-focusring {
+  @include focus_BoxShadow_Small;
+  outline: 0;
+}
 
-// select:focus {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
-// select.focus-visible:focus:not(:focus-visible) {
-//   box-shadow: none;
-//   outline: 0;
-// }
-// select.focus-visible:focus-visible, select.focus-visible:moz-focusring {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
+input.focus-visible:focus-visible,
+input.focus-visible:moz-focusring {
+  @include focus_BoxShadow_Small;
+  outline: 0;
+}
 
-// textarea:focus {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
-// textarea.focus-visible:focus:not(:focus-visible) {
-//   box-shadow: none;
-//   outline: 0;
-// }
-// textarea.focus-visible:focus-visible, textarea.focus-visible:moz-focusring {
-//   @include focus_BoxShadow_Small;
-//   outline: 0;
-// }
+select.focus-visible:focus-visible,
+select.focus-visible:moz-focusring {
+  @include focus_BoxShadow_Small;
+  outline: 0;
+}
+
+textarea.focus-visible:focus-visible,
+textarea.focus-visible:moz-focusring {
+  @include focus_BoxShadow_Small;
+  outline: 0;
+}
 
 // ////////////////////////////////////////////////////////////// [Post] Imports
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Focus rings will now only appear on tabbable elements on tab and not on click. Unfortunately, the condensed scss syntax for `.focus-visible` cross browser styling doesn't seem to work. This change strikes a compromise between code verbosity and function :)