### PR TITLE
Fix: segment chart label spacing

### DIFF
--- a/assets/scss/components.scss
+++ b/assets/scss/components.scss
@@ -104,8 +104,14 @@
 
 #segment-slider-chart {
   // -------------------------------------------------------------------- Mobile
+  @include medium {
+    background-color: white;
+  }
   .segments-tiny {
     background-color: $site_backgroundColor;
+    @include medium {
+      background-color: white;
+    }
   }
   // ------------------------------------------------------------------ Segments
   .segment-foreground {

--- a/components/Shipyard_SegmentSlider.vue
+++ b/components/Shipyard_SegmentSlider.vue
@@ -137,6 +137,12 @@ const createLabels = (instance, projects) => {
   return false
 }
 
+const getLongestWord = (label) => {
+  const arr = []
+  label.split(' ').forEach((word) => { arr.push(word.split('').length) })
+  return Math.max(...arr)
+}
+
 // ====================================================================== Export
 export default {
   name: 'ShipyardSegmentSlider',

--- a/components/Shipyard_SegmentSliderChart.vue
+++ b/components/Shipyard_SegmentSliderChart.vue
@@ -28,27 +28,27 @@
             <span
               v-if="item.above"
               class="segment-label noselect avoid-me"
-              :style="`width: ${Math.min(item.chars, 15) * 8}px; top: ${item.pos}px`">
+              :style="`width: ${Math.min(item.chars, 15) * 8}px; top: ${item.pos * scalar}px`">
               {{ item.label }}
             </span>
 
             <span
               v-else
               class="segment-label noselect avoid-me"
-              :style="`width: ${Math.min(item.chars, 15) * 8}px; top: ${-1 * (item.pos) + segH / 2}px`">
+              :style="`width: ${Math.min(item.chars, 15) * 8}px; top: ${-1 * (item.pos * scalar) + segH / 2}px`">
               {{ item.label }}
             </span>
 
             <div
               v-if="item.above"
               class="segment-line avoid-me"
-              :style="`top: ${-6}px; height: ${Math.abs(item.pos) - item.labelHeight - 12}px; transform: rotate(180deg);`">
+              :style="`top: ${-6}px; height: ${Math.abs(item.pos * scalar) - item.labelHeight - 12}px; transform: rotate(180deg);`">
             </div>
 
             <div
               v-else
               class="segment-line avoid-me"
-              :style="`top: ${segH + 6}px; height: ${Math.abs(item.pos) - 26}px`">
+              :style="`top: ${segH + 6}px; height: ${Math.abs(item.pos * scalar) - 26}px`">
             </div>
 
           </template>
@@ -185,6 +185,7 @@ export default {
   data () {
     return {
       segH: 30,
+      scalar: 1.3,
       segments: this.chartItems,
       measured: false,
       timeOutFunction: null,


### PR DESCRIPTION
Spacing added between label heights avoids collisions and therefore avoids hiding labels.