### PR TITLE
fix: Strip slashes in primary button tooltip

### DIFF
--- a/pages/_project.vue
+++ b/pages/_project.vue
@@ -28,17 +28,7 @@
             {{ description }}
           </p>
           <div class="ctas">
-            <a
-              v-if="project.primaryCta && project.primaryCta.url && project.primaryCta.text"
-              :href="project.primaryCta.url"
-              target="_blank"
-              class="primary-cta focus-visible">
-              <span
-                :data-tooltip="project.primaryCta.url"
-                data-tooltip-theme="dark">
-                {{ project.primaryCta.text }}
-              </span>
-            </a>
+            
             <nuxt-link to="/" class="secondary-cta focus-visible">
               <span class="text">
                 {{ secondaryCtaButtonText }}
@@ -414,6 +404,9 @@ export default {
         return null
       }
       return text.length > 23 ? text : false
+    },
+    stripSlashes (text) {
+      return project.primaryCta.url.substring(0, 2) == '\/\/' ? project.primaryCta.url.substring(2) : project.primaryCta.url
     }
   }
 }

--- a/pages/_project.vue
+++ b/pages/_project.vue
@@ -38,7 +38,7 @@
                 data-tooltip-theme="dark">
                 {{ project.primaryCta.text }}
               </span>
-            </a>            
+            </a>
             <nuxt-link to="/" class="secondary-cta focus-visible">
               <span class="text">
                 {{ secondaryCtaButtonText }}
@@ -86,7 +86,7 @@
                           class="focus-visible"
                           :data-tooltip="generateToolTip(link.text)"
                           data-tooltip-theme="dark">
-                          {{ truncateLinks ? $TruncateString(link.text, 12, '...', type = 'double') : link.text }}
+                          {{ truncateLinks ? $TruncateString(link.text, 14, '...', type = 'double', 14) : link.text }}
                         </a>
                       </li>
                     </template>

--- a/pages/_project.vue
+++ b/pages/_project.vue
@@ -28,7 +28,17 @@
             {{ description }}
           </p>
           <div class="ctas">
-            
+            <a
+              v-if="project.primaryCta && project.primaryCta.url && project.primaryCta.text"
+              :href="project.primaryCta.url"
+              target="_blank"
+              class="primary-cta focus-visible">
+              <span
+                :data-tooltip="project.primaryCta.url"
+                data-tooltip-theme="dark">
+                {{ project.primaryCta.text }}
+              </span>
+            </a>            
             <nuxt-link to="/" class="secondary-cta focus-visible">
               <span class="text">
                 {{ secondaryCtaButtonText }}


### PR DESCRIPTION
Checks for slashes in the beginning of the tooltip output and strips them