### PR TITLE
feat: Add error page data to store site content on error layout

### DIFF
--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -105,6 +105,7 @@ export default {
   methods: {
     getData () {
       this.$store.dispatch('global/getBaseData', { key: 'core' })
+      this.$store.dispatch('global/getBaseData', { key: 'general' })
     },
     generateWidths () {
       let arr = []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/nuxt-module-ecosystem-directory",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/nuxt-module-ecosystem-directory",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "A Nuxt module that loads all the boilerplate layouts, pages, components, styles, stores and functionality to run the Ecosystem Directory.",
   "keywords": [
     "Nuxt",


### PR DESCRIPTION
A small fix to the error page layout which did not have general site content data included in the getBase data fetch hook. Now general site data including 404 page content is included and the error page renders correctly.