### PR TITLE
refactor: Slot based segment chart

### DIFF
--- a/components/Shipyard_SegmentSlider.vue
+++ b/components/Shipyard_SegmentSlider.vue
@@ -32,7 +32,6 @@
 <script>
 // ===================================================================== Imports
 import { mapGetters } from 'vuex'
-
 // =================================================================== Functions
 const loadTaxonomies = (instance) => {
   const primary = {}
@@ -44,17 +43,14 @@ const loadTaxonomies = (instance) => {
       description: categories[i].description
     }
   }
-
   if (primary.hasOwnProperty(instance.settings.behavior.firstTag)) {
     primary[instance.settings.behavior.firstTag].priority = 'first'
   }
   if (primary.hasOwnProperty(instance.settings.behavior.lastTag)) {
     primary[instance.settings.behavior.lastTag].priority = 'last'
   }
-
   return primary
 }
-
 const initCategoryLogos = (instance) => {
   const logos = {}
   const categories = instance.primaryCategory.tags
@@ -63,13 +59,11 @@ const initCategoryLogos = (instance) => {
   }
   return logos
 }
-
 const createLabels = (instance, projects) => {
   const tags = []
   const len = projects.length
   const primary = loadTaxonomies(instance)
   const logos = initCategoryLogos(instance)
-
   for (let i = 0; i < len; i++) {
     const projectTaxonomy = projects[i].taxonomies.find(category => category.slug === instance.primaryCategory.slug)
     if (projectTaxonomy.tags) {
@@ -89,7 +83,6 @@ const createLabels = (instance, projects) => {
       }
     }
   }
-
   if (tags.length) {
     const categories = [...new Set(tags)]
     const items = []
@@ -101,9 +94,7 @@ const createLabels = (instance, projects) => {
         let selection = []
         const label = primary[category].label
         const description = primary[category].description
-        const l = label.split('').length
         const icons = logos[category]
-
         if (icons.length) {
           if (icons.length > 3) {
             for (let j = 0; j < 3; j++) {
@@ -115,16 +106,13 @@ const createLabels = (instance, projects) => {
             selection = icons
           }
         }
-
         tags.forEach((tag) => { if (tag === category) { count++ } })
         const obj = {
-          label,
+          label: { text: label },
           description,
+          count,
           slug: category,
-          size: count * 10,
-          chars: l,
-          logos: selection,
-          display: false
+          logos: selection
         }
         if (primary[category].hasOwnProperty('priority')) {
           obj.priority = primary[category].priority
@@ -135,12 +123,6 @@ const createLabels = (instance, projects) => {
     return items
   }
   return false
-}
-
-const getLongestWord = (label) => {
-  const arr = []
-  label.split(' ').forEach((word) => { arr.push(word.split('').length) })
-  return Math.max(...arr)
 }
 
 // ====================================================================== Export

--- a/components/Shipyard_SegmentSliderChart.vue
+++ b/components/Shipyard_SegmentSliderChart.vue
@@ -31,7 +31,7 @@
 
           <div
             :class="['indicator', 'slot-1', index % 2 === 0 ? 'above' : 'below']"
-            :style="`width: ${item.segment.s1.length}px; left: ${item.segment.ihw}px; top: ${getLabelOffset(item, index, 'first')}px;`">
+            :style="`width: ${item.segment.s1.length}px; top: ${getLabelOffset(item, index, 'first')}px;`">
             <template v-if="item.segment.s1.occupied">
               <div class="label">
                 <div class="stem-relative-wrap" :style="`width: ${item.label.width}px;`">
@@ -46,7 +46,7 @@
           </div>
           <div
             :class="['indicator', 'slot-2', index % 2 === 0 ? 'above' : 'below']"
-            :style="`width: ${item.segment.s2.length}px; left: ${item.segment.ihw}px; top: ${getLabelOffset(item, index, 'second')}px;`">
+            :style="`width: ${item.segment.s2.length}px; top: ${getLabelOffset(item, index, 'second')}px;`">
             <template v-if="item.segment.s2.occupied">
               <div class="label">
                 <div class="stem-relative-wrap" :style="`width: ${item.label.width}px;`">
@@ -61,7 +61,7 @@
           </div>
           <div
             :class="['indicator', 'slot-3', index % 2 === 0 ? 'above' : 'below']"
-            :style="`width: ${item.segment.s3.length}px; left: ${item.segment.ihw}px; top: ${getLabelOffset(item, index, 'third')}px;`">
+            :style="`width: ${item.segment.s3.length}px; top: ${getLabelOffset(item, index, 'third')}px;`">
             <template v-if="item.segment.s3.occupied">
               <div class="label">
                 <div class="stem-relative-wrap" :style="`width: ${item.label.width}px;`">
@@ -303,9 +303,9 @@ export default {
       measured: false,
       random: 10,
       tiers: {
-        first: 60,
-        second: 100,
-        third: 140
+        first: 50,
+        second: 90,
+        third: 130
       }
     }
   },
@@ -421,6 +421,7 @@ export default {
   @include small {
     padding: 0 3rem;
     padding-bottom: 0;
+    height: unset !important;
   }
   @include tiny {
     min-width: 16rem;
@@ -510,6 +511,7 @@ $segmentStemGap: 6px;
   }
   .indicator {
     position: absolute;
+    left: 50%;
 
     &.below {
       transform: translateY(2rem);

--- a/components/Shipyard_SegmentSliderChart.vue
+++ b/components/Shipyard_SegmentSliderChart.vue
@@ -1,59 +1,87 @@
 <template>
   <div id="segment-slider-chart" ref="chartFlex" class="chart-container">
-    <div ref="segmentsCtn" class="segments-container">
+    <div
+      ref="segmentsCtn"
+      class="segments-container"
+      :style="`height: ${tiers.third * 2}px;`">
 
       <div class="chart-title">
         <h3>{{ mobileChartTitle }}</h3>
       </div>
 
-      <template v-if="!measured">
-        <div
-          v-for="item in segments"
-          :key="`dummy-${item.label}`"
-          class="measure">
-          {{ item.label }}
-        </div>
-      </template>
+      <div
+        v-for="item in segments"
+        :key="`dummy-${item.label.text}`"
+        ref="dummyLabels"
+        class="measure">
+        {{ item.label.text }}
+      </div>
 
-      <div class="segments-row">
+      <div
+        v-if="measured"
+        ref="segmentsRow"
+        :class="['segments-row', measured ? '' : 'fixed-for-measuring']">
+
         <div
           v-for="(item, index) in segments"
           :key="index"
-          :class="setForegrounded(index)"
-          :style="`width: ${item.size}%; height: ${segH}px;`"
+          :class="['segment-wrapper', selectedSeg === index ? 'selected' : '']"
+          :style="getSegmentStyle(item, index)"
           @click="updateParent(index)">
 
-          <template v-if="measured && item.display">
+          <div
+            :class="['indicator', 'slot-1', index % 2 === 0 ? 'above' : 'below']"
+            :style="`width: ${item.segment.s1.length}px; left: ${item.segment.ihw}px; top: ${getLabelOffset(item, index, 'first')}px;`">
+            <template v-if="item.segment.s1.occupied">
+              <div class="label">
+                <div class="stem-relative-wrap" :style="`width: ${item.label.width}px;`">
+                  <span class="label-text">{{ item.label.text }}</span>
+                  <div
+                    class="stem first"
+                    :style="`height: ${tiers.first + item.label.offset}px;`">
+                  </div>
+                </div>
+              </div>
+            </template>
+          </div>
+          <div
+            :class="['indicator', 'slot-2', index % 2 === 0 ? 'above' : 'below']"
+            :style="`width: ${item.segment.s2.length}px; left: ${item.segment.ihw}px; top: ${getLabelOffset(item, index, 'second')}px;`">
+            <template v-if="item.segment.s2.occupied">
+              <div class="label">
+                <div class="stem-relative-wrap" :style="`width: ${item.label.width}px;`">
+                  <span class="label-text">{{ item.label.text }}</span>
+                  <div
+                    class="stem second"
+                    :style="`height: ${tiers.second + item.label.offset}px;`">
+                  </div>
+                </div>
+              </div>
+            </template>
+          </div>
+          <div
+            :class="['indicator', 'slot-3', index % 2 === 0 ? 'above' : 'below']"
+            :style="`width: ${item.segment.s3.length}px; left: ${item.segment.ihw}px; top: ${getLabelOffset(item, index, 'third')}px;`">
+            <template v-if="item.segment.s3.occupied">
+              <div class="label">
+                <div class="stem-relative-wrap" :style="`width: ${item.label.width}px;`">
+                  <span class="label-text">{{ item.label.text }}</span>
+                  <div
+                    class="stem third"
+                    :style="`height: ${tiers.third + item.label.offset}px;`">
+                  </div>
+                </div>
+              </div>
+            </template>
+          </div>
 
-            <span
-              v-if="item.above"
-              class="segment-label noselect avoid-me"
-              :style="`width: ${Math.min(item.chars, 15) * 8}px; top: ${item.pos * scalar}px`">
-              {{ item.label }}
-            </span>
-
-            <span
-              v-else
-              class="segment-label noselect avoid-me"
-              :style="`width: ${Math.min(item.chars, 15) * 8}px; top: ${-1 * (item.pos * scalar) + segH / 2}px`">
-              {{ item.label }}
-            </span>
-
-            <div
-              v-if="item.above"
-              class="segment-line avoid-me"
-              :style="`top: ${-6}px; height: ${Math.abs(item.pos * scalar) - item.labelHeight - 12}px; transform: rotate(180deg);`">
-            </div>
-
-            <div
-              v-else
-              class="segment-line avoid-me"
-              :style="`top: ${segH + 6}px; height: ${Math.abs(item.pos * scalar) - 26}px`">
-            </div>
-
-          </template>
+          <div
+            :class="['block-segment', setForegrounded(index), { 'displaced-down': (item.count > 4) && index % 2 === 0 }, { 'displaced-up': (item.count > 4) && index % 2 === 1 }]">
+            <div class="dots"></div>
+          </div>
 
         </div>
+
       </div>
 
     </div>
@@ -66,33 +94,143 @@ import { mapGetters, mapActions } from 'vuex'
 import CloneDeep from 'lodash/cloneDeep'
 
 // =================================================================== Functions
-const handleLoad = (instance) => {
-  instance.handleResize()
+const calculateSegmentAndLabelData = (dummies, instance, next) => {
+  for (let i = 0; i < dummies.length; i++) {
+    const rect = dummies[i].getBoundingClientRect()
+    const dimensions = {
+      width: rect.width,
+      height: rect.height,
+      offset: Math.random() * instance.random
+    }
+    Object.assign(instance.segments[i].label, dimensions)
+
+    const num = instance.segments[i].count
+    const percent = num / instance.totalProjects
+    instance.segments[i].segment = {
+      percent: percent * 100,
+      ihw: (percent * 572) / 2
+    }
+  }
+
+  return next()
 }
 
-const initResize = (instance) => {
-  clearTimeout(instance.timeOutFunction)
-  instance.timeOutFunction = setTimeout(() => { instance.handleResize() }, 250)
+const calculateSlotsData = (instance, next) => {
+  const len = instance.segments.length
+  for (let i = 0; i < len; i++) {
+    const items = instance.segments
+    const hasFirstNeighbor = i < len - 2
+    items[i].segment.s1 = {
+      length: hasFirstNeighbor
+        ? (
+            items[i].segment.ihw +
+            items[i + 1].segment.ihw * 2 +
+            items[i + 2].segment.ihw
+          )
+        : 1000,
+      occupied: false
+    }
+
+    const hasSecondNeighbor = i < len - 4
+    items[i].segment.s2 = {
+      length: hasSecondNeighbor
+        ? (
+            items[i].segment.ihw +
+            items[i + 1].segment.ihw * 2 +
+            items[i + 2].segment.ihw * 2 +
+            items[i + 3].segment.ihw * 2 +
+            items[i + 4].segment.ihw
+          )
+        : 1000,
+      occupied: false
+    }
+
+    const hasThirdNeighbor = i < len - 6
+    items[i].segment.s3 = {
+      length: hasThirdNeighbor
+        ? (
+            items[i].segment.ihw +
+            items[i + 1].segment.ihw * 2 +
+            items[i + 2].segment.ihw * 2 +
+            items[i + 3].segment.ihw * 2 +
+            items[i + 4].segment.ihw * 2 +
+            items[i + 5].segment.ihw * 2 +
+            items[i + 6].segment.ihw
+          )
+        : 1000,
+      occupied: false
+    }
+  }
+
+  instance.measured = true
+  return next()
 }
 
-const calculateSegmentAndLabelPositions = (instance) => {
-  const labels = document.querySelectorAll('.measure')
-  const segments = document.querySelectorAll('.block-segment')
+const positionFirstTierLabels = (instance, n, next) => {
+  const segments = instance.segments
+  for (let i = n; i < segments.length; i = i + 2) {
+    if (segments[i].label.width < segments[i].segment.s1.length) {
+      segments[i].segment.s1.occupied = true
+    }
+  }
+  return next()
+}
+
+const positionSecondTierLabels = (instance, n, next) => {
+  const segments = instance.segments
+  const modulo = Boolean(segments.length % 2)
+  const start = (segments.length - 1 - (!modulo ? n : n ? 0 : 1))
+  for (let i = start; n <= i; i = i - 2) {
+  // for (let i = n; i < segments.length; i = i + 2) {
+
+    const h = Math.max(i - 2, n)
+    const j = Math.min(i + 2, start)
+
+    if (
+      segments[i].label.width < segments[i].segment.s2.length &&
+      !segments[i].segment.s1.occupied &&
+      !segments[h].segment.s2.occupied && !segments[j].segment.s2.occupied &&
+      !segments[j].segment.s3.occupied
+    ) {
+      segments[i].segment.s2.occupied = true
+    }
+  }
+  return next()
+}
+
+const positionThirdTierLabels = (instance, n, next) => {
+  const segments = instance.segments
+  const modulo = Boolean(segments.length % 2)
+  const end = (segments.length - 1 - (!modulo ? n : n ? 0 : 1))
+  for (let i = n; i < segments.length; i = i + 2) {
+    const g = Math.max(i - 4, n)
+    const h = Math.max(i - 2, n)
+    const j = Math.min(i + 2, end)
+    const k = Math.min(i + 4, end)
+
+    if (
+      segments[i].label.width < segments[i].segment.s3.length &&
+      !segments[i].segment.s1.occupied &&
+      !segments[h].segment.s2.occupied && !segments[i].segment.s2.occupied &&
+      !segments[g].segment.s3.occupied && !segments[h].segment.s3.occupied && !segments[j].segment.s3.occupied && !segments[k].segment.s3.occupied
+    ) {
+      segments[i].segment.s3.occupied = true
+    }
+  }
+  return next()
+}
+
+const reOrderBasedOnScore = (instance, next) => {
+  const segments = instance.segments
 
   const ordered = []
-  for (let i = 0; i < labels.length; i++) {
-    const score = -1 * ((segments[i].offsetWidth / 2) - labels[i].offsetWidth)
-    instance.segments[i].labelHeight = labels[i].offsetHeight
+  for (let i = 0; i < segments.length; i++) {
+    const score = -1 * (segments[i].segment.ihw - segments[i].label.width)
     instance.segments[i].score = score
   }
 
   const ascending = CloneDeep(instance.segments)
   ascending.sort((a, b) => a.score - b.score)
-  for (let i = 0; i < ascending.length; i++) {
-    ascending[i].above = i % 2
-    ascending[i].pos = (25 + ascending[i].score) * -1
-    ascending[i].offset = (25 + ascending[i].score) * -1
-  }
 
   let last, first
   for (let i = 0; i < ascending.length; i++) {
@@ -115,56 +253,33 @@ const calculateSegmentAndLabelPositions = (instance) => {
   const l = ascending.length
   const s = Math.ceil(l / 2)
 
-  for (let i = 0; i < s; i++) {
-    ordered.push(ascending[l - i - 1])
-    if (i !== l - i - 1) {
+  const firstHalf = ascending.splice(0, s)
+  ascending.reverse()
+
+  for (let i = 0; i < s; i = i + 2) {
+    if (typeof ascending[i] !== 'undefined') {
       ordered.push(ascending[i])
     }
+    if (typeof ascending[i + 1] !== 'undefined') {
+      ordered.push(ascending[i + 1])
+    }
+    if (typeof firstHalf[i] !== 'undefined') {
+      ordered.push(firstHalf[i])
+    }
+    if (typeof firstHalf[i + 1] !== 'undefined') {
+      ordered.push(firstHalf[i + 1])
+    }
   }
-
   ordered.reverse()
 
   if (first) { ordered.unshift(first[0]) }
   if (last) { ordered.push(last[0]) }
 
-  for (let i = 0; i < ordered.length - 1; i++) {
-    const sum = (ordered[i].above ? 1 : 0) + (ordered[i + 1].above ? 1 : 0)
-    if (sum !== 1) {
-      if (ordered[i].pos > ordered[i + 1].pos) {
-        const p = ordered[i].pos
-        ordered[i].pos = ordered[i + 1].pos
-        ordered[i + 1].pos = p
-        ordered[i].offset = ordered[i].pos
-        ordered[i + 1].offset = ordered[i + 1].pos
-      }
-    }
-  }
-
   instance.measured = true
   instance.segments = ordered
   const col = CloneDeep(instance.segments)
   instance.setSegmentCollection(col)
-  handleLoad(instance)
-}
-
-const doNotOverlap = (item1, item2, lookahead) => {
-  const rect1 = item1.getBoundingClientRect()
-  const rect2 = item2.getBoundingClientRect()
-  return (
-    rect1.right < rect2.left ||
-    rect1.left > rect2.right ||
-    rect1.bottom + lookahead < rect2.top ||
-    rect1.top + lookahead > rect2.bottom
-  )
-}
-
-const removeMatchingLabel = (instance, label) => {
-  const len = instance.segments.length
-  for (let i = 0; i < len; i++) {
-    if (instance.segments[i].label === label) {
-      instance.segments[i].display = false
-    }
-  }
+  return next()
 }
 
 // ====================================================================== Export
@@ -184,12 +299,14 @@ export default {
 
   data () {
     return {
-      segH: 30,
-      scalar: 1.3,
       segments: this.chartItems,
       measured: false,
-      timeOutFunction: null,
-      resize: false
+      random: 10,
+      tiers: {
+        first: 60,
+        second: 100,
+        third: 140
+      }
     }
   },
 
@@ -203,6 +320,13 @@ export default {
     },
     mobileChartTitle () {
       return this.segmentSliderContent.mobile_chart_title
+    },
+    totalProjects () {
+      let total = 0
+      for (let i = 0; i < this.chartItems.length; i++) {
+        total = total + this.chartItems[i].count
+      }
+      return total
     }
   },
 
@@ -219,13 +343,29 @@ export default {
   },
 
   mounted () {
-    calculateSegmentAndLabelPositions(this)
-    this.resize = () => { initResize(this) }
-    window.addEventListener('resize', this.resize)
-  },
-
-  beforeDestroy () {
-    if (this.resize) { window.removeEventListener('resize', this.resize) }
+    this.$nextTick(() => {
+      if (this.$refs.dummyLabels?.length === this.chartItems.length) {
+        calculateSegmentAndLabelData(this.$refs.dummyLabels, this, () => {
+          reOrderBasedOnScore(this, () => {
+            calculateSlotsData(this, () => {
+              positionFirstTierLabels(this, 0, () => {
+                positionFirstTierLabels(this, 1, () => {
+                  positionSecondTierLabels(this, 0, () => {
+                    positionSecondTierLabels(this, 1, () => {
+                      positionThirdTierLabels(this, 0, () => {
+                        positionThirdTierLabels(this, 1, () => {
+                          console.log('labels loaded')
+                        })
+                      })
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      }
+    })
   },
 
   methods: {
@@ -236,71 +376,13 @@ export default {
       this.$emit('update-slider', seg)
     },
     setForegrounded (ind) {
-      const x = (this.selectedSeg === ind) ? 'segment-foreground' : 'segment-background'
-      return 'block-segment' + ' ' + x
+      return (this.selectedSeg === ind) ? 'segment-foreground' : 'segment-background'
     },
-    setMinOffsets (next) {
-      for (let ind = 0; ind < this.segments.length; ind++) {
-        this.segments[ind].pos = Math.min(-50, this.segments[ind].pos)
-      }
-      return next()
+    getSegmentStyle (item, i) {
+      return `width: ${item.segment.percent}%; z-index: ${this.segments.length - i};`
     },
-    reduceOffset (amt, repeats, next) {
-      if (repeats > 0) {
-        const labels = document.getElementsByClassName('segment-label')
-        for (let i = 0; i < this.segments.length; i++) {
-          const overlaps = []
-          const dir = this.segments[i].above ? amt : (-1 * amt)
-          for (let j = 0; j < this.segments.length; j++) {
-            if (labels[i] && labels[j] && j !== i) {
-              overlaps.push(doNotOverlap(labels[i], labels[j], dir))
-            }
-          }
-          if (overlaps.every(Boolean)) {
-            this.segments[i].pos = Math.min(this.segments[i].pos + amt, -20 - this.segments[i].labelHeight)
-          }
-        }
-        const num = repeats - 1
-        window.requestAnimationFrame(() => { this.reduceOffset(amt, num, next) })
-      } else {
-        next()
-      }
-    },
-    dropOverLappingLabels () {
-      const labels = document.getElementsByClassName('segment-label')
-      const targets = document.getElementsByClassName('avoid-me')
-      const overlaps = []
-      for (let i = 0; i < labels.length; i++) {
-        for (let j = 0; j < targets.length; j++) {
-          if (!doNotOverlap(labels[i], targets[j], 0) && targets[j] !== labels[i]) {
-            overlaps.push(i)
-            break
-          }
-        }
-      }
-      if (overlaps.length) {
-        const ind = overlaps.pop()
-        removeMatchingLabel(this, labels[ind].innerText)
-        window.requestAnimationFrame(this.dropOverLappingLabels)
-      }
-    },
-    handleResize () {
-      if (window.matchMedia('(max-width: 64rem)').matches) {
-        this.$refs.segmentsCtn.classList.remove('segments-large')
-        this.$refs.segmentsCtn.classList.add('segments-tiny')
-      } else {
-        this.$refs.segmentsCtn.classList.remove('segments-tiny')
-        this.$refs.segmentsCtn.classList.add('segments-large')
-      }
-      const len = this.segments.length
-      for (let i = 0; i < len; i++) {
-        this.segments[i].pos = this.segments[i].offset - 10
-        this.segments[i].display = true
-      }
-      this.reduceOffset(12, 4, () => {
-        this.dropOverLappingLabels()
-        this.$nextTick(() => { this.$emit('chart-mounted') })
-      })
+    getLabelOffset (item, i, tier) {
+      return ((-1 * this.tiers[tier]) - item.label.offset) * (i % 2 === 0 ? 1 : -1)
     }
   }
 }
@@ -308,6 +390,21 @@ export default {
 
 <style lang="scss" scoped>
 // ///////////////////////////////////////////////////////////////////// General
+#segment-slider-chart {
+  padding-top: 2rem;
+  @include large {
+    margin-bottom: 3rem;
+  }
+  @include medium {
+    padding-top: 6rem;
+    margin-bottom: 0;
+  }
+  @include small {
+    padding-top: 0;
+    margin-bottom: 0rem;
+  }
+}
+
 .chart-container {
   position: relative;
   flex: 3 1 42.75rem;
@@ -330,57 +427,160 @@ export default {
     padding: 0 2rem;
     padding-bottom: 0;
   }
-  > div {
-    margin: 2px;
-  }
 }
 
 .chart-title {
   visibility: hidden;
-  padding: 4.75rem 0;
-  @include medium {
-    padding: 2.5rem 0;
-  }
+  height: 50%;
+  margin: 0;
   @include small {
     visibility: visible;
     padding: 2rem 0;
   }
 }
 
+$segmentStemGap: 6px;
+
 .segments-row {
+  position: relative;
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: flex-start;
   > div {
-    margin: 2px;
+    margin: 0 2px;
+  }
+
+  &.fixed-for-measuring {
+    width: 572px;
+  }
+
+  &:before {
+    content: '';
+    position: absolute;
+    top: calc(0px - #{$segmentStemGap});
+    left: 0;
+    height: $segmentStemGap;
+    width: 100%;
+    background-color: $site_backgroundColor;
+    z-index: 1000;
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 0;
+    height: $segmentStemGap;
+    width: 100%;
+    background-color: $site_backgroundColor;
+    z-index: 1000;
+  }
+
+  @include medium {
+    &:before,
+    &:after {
+      background-color: white;
+    }
   }
 }
 
-.segments-large {
-  min-height: 24rem;
-  top: 0px;
+// ///////////////////////////////////////////////// Segments functional styling
+.measure {
+  display: inline-block;
+  position: absolute;
+  font-family: $font_Secondary;
+  letter-spacing: 0.015em;
+  line-height: $leading_Tiny;
+  font-size: $fontSize_Mini;
+  max-width: 120px;
+  margin: 0;
+  color: red;
+  opacity: 0.0;
+  font-size: 11pt;
 }
 
-.segments-tiny {
-  min-height: 10rem;
-  top: 1.5rem;
+.segment-wrapper {
+  position: relative;
+  height: 1.75rem;
+  box-sizing: border-box;
+  .segment-id {
+    font-size: 5px;
+    line-height: 1;
+  }
+  .indicator {
+    position: absolute;
+
+    &.below {
+      transform: translateY(2rem);
+      .stem {
+        transform: translateY(-4px) rotate(180deg);
+        bottom: unset;
+        top: 0;
+      }
+    }
+
+    .label {
+      position: absolute;
+      top: -0.5rem;
+      left: 0;
+      text-align: left;
+      line-height: $leading_Tiny;
+      z-index: -1000;
+      @include small {
+        display: none;
+      }
+      .label-text {
+        top: 0;
+        left: 0;
+        color: #181818;
+        font-family: $font_Secondary;
+        font-size: 0.625rem;
+        letter-spacing: 0.015em;
+        line-height: $leading_Tiny;
+        text-align: left;
+        user-select: none;
+        white-space: normal;
+        transition: 250ms linear;
+      }
+    }
+
+    .stem-relative-wrap {
+      position: relative;
+      width: 100%;
+      height: 100%;
+    }
+    .stem {
+      position: absolute;
+      border-left: 1px solid rgba(#181818, 0.1);
+      left: 0;
+      bottom: 0;
+      transform-origin: top;
+      transform: translateY(calc(100% + 4px));
+      z-index: -1000;
+    }
+  }
+
+  &.selected {
+    .label-text {
+      font-weight: bold;
+    }
+  }
 }
 
-.space-segment {
-  width: 7px;
-}
-
-// //////////////////////////////////////////////////////////////////// Segments
 .segment-foreground {
-  font-weight: bold;
+  &:after {
+    background-position: 100% 0%;
+  }
 }
 
 .block-segment {
   @include borderRadius_Small;
   position: relative;
-  max-width: 20%;
-  min-width: 7px;
+  height: 100%;
+  width: 100%;
+  top: 0px;
+  left: 0px;
   cursor: pointer;
   transition: background-color 250ms linear, font-weight 250ms linear;
   &:before {
@@ -397,42 +597,5 @@ export default {
   &:hover:before {
     transform: scale(1.02, 1.15);
   }
-}
-
-.measure,
-.segment-label {
-  white-space: normal;
-  padding: 0px;
-  font-size: 10pt;
-  text-align: left;
-  transform: translateX(-3px);
-  @include small {
-    display: none;
-  }
-}
-
-.measure {
-  display: inline-block;
-  position: relative;
-  max-width: 120px;
-  margin: 0 !important;
-}
-
-.segment-label {
-  position: absolute;
-}
-
-.segment-line {
-  position: absolute;
-  left: 50%;
-  width: 2px;
-  transform-origin: top left;
-  @include small {
-    display: none;
-  }
-}
-
-.noselect {
-  user-select: none;
 }
 </style>

--- a/components/Shipyard_SegmentSliderSlider.vue
+++ b/components/Shipyard_SegmentSliderSlider.vue
@@ -15,10 +15,10 @@
         </button>
 
         <h3
-          :key="`${currentCategory.label}-medium`"
+          :key="`${heading}-medium`"
           ref="navTitle"
           class="title-between-buttons transition-content">
-          {{ currentCategory.label }}
+          {{ heading }}
         </h3>
 
         <button
@@ -30,16 +30,16 @@
         </button>
       </div>
 
-      <div :key="currentCategory.label" class="transition-content">
+      <div :key="heading" class="transition-content">
         <div ref="content">
           <div class="title-large-screen">
             <h3>
-              {{ currentCategory.label }}
+              {{ heading }}
             </h3>
           </div>
 
           <div class="description">
-            {{ currentCategory.description ? currentCategory.description : '' }}
+            {{ description }}
           </div>
         </div>
 
@@ -108,17 +108,23 @@ export default {
     filterToggleButtonText () {
       return this.siteContent.index.page_content.segment_slider.filter_toggle_button_text
     },
-    logos () {
-      if (this.currentCategory.hasOwnProperty('logos')) {
-        return this.currentCategory.logos
-      }
-      return false
-    },
     currentCategory () {
       if (this.selectedSeg in this.segmentCollection) {
         return this.segmentCollection[this.selectedSeg]
       }
       return {}
+    },
+    heading () {
+      return this.currentCategory.label ? this.currentCategory.label.text : ''
+    },
+    description () {
+      return this.currentCategory.description ? this.currentCategory.description : ''
+    },
+    logos () {
+      if (this.currentCategory.hasOwnProperty('logos')) {
+        return this.currentCategory.logos
+      }
+      return false
     },
     cardHeight () {
       if (this.contentHeight) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/nuxt-module-ecosystem-directory",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/nuxt-module-ecosystem-directory",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "A Nuxt module that loads all the boilerplate layouts, pages, components, styles, stores and functionality to run the Ecosystem Directory.",
   "keywords": [
     "Nuxt",


### PR DESCRIPTION
This refactor changes the architecture of the segment slider chart. Labels are now positioned according to discrete position possibilities, i.e. slots, following the implementation in [Ecodash](https://github.com/filecoin-project/ecodash/pull/66).