### PR TITLE
feat: Optional entity count number added to index page filters heading

### DIFF
--- a/content/data/settings.json
+++ b/content/data/settings.json
@@ -35,7 +35,8 @@
     "truncateCharacters": [12, 10],
     "mediaAltAtts": true,
     "linksAltAtts": true,
-    "singularTagLinks": true
+    "singularTagLinks": true,
+    "indexHeadingEntityCount": false
   },
   "embeddable_view": {
     "host": "https://example.on.fleek.co/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/nuxt-module-ecosystem-directory",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/nuxt-module-ecosystem-directory",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "A Nuxt module that loads all the boilerplate layouts, pages, components, styles, stores and functionality to run the Ecosystem Directory.",
   "keywords": [
     "Nuxt",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -55,7 +55,7 @@
             <div class="col">
 
               <h3 class="heading">
-                {{ pageData.section_filter.heading }}
+                {{ filterSectionHeading }}
               </h3>
 
               <div class="description">
@@ -239,7 +239,8 @@ export default {
       siteContent: 'global/siteContent',
       routeQuery: 'filters/routeQuery',
       filterPanelOpen: 'filters/filterPanelOpen',
-      taxonomyLabels: 'filters/taxonomyLabels'
+      taxonomyLabels: 'filters/taxonomyLabels',
+      projects: 'projects/projects'
     }),
     settings () {
       return this.siteContent.settings
@@ -260,6 +261,21 @@ export default {
         return true
       }
       return false
+    },
+    filterSectionHeading () {
+      if (this.settings.visibility.indexHeadingEntityCount) {
+        const heading = this.pageData.section_filter.heading
+        const arr = heading.split(' ')
+        const index = arr.findIndex((word) => {
+          return (
+            word === this.settings.nomenclature.entityTermPlural
+            || word === this.settings.nomenclature.entityTerm
+          )
+        })
+        arr.splice(index, 0, this.projects.length)
+        return arr.join(' ')
+      }
+      return this.pageData.section_filter.heading
     }
   },
 


### PR DESCRIPTION
Option added to display the total number of entities in the ecosystem directory inside the index page filters heading as `string + n + entityNamePlural`. ex: "All 97 Projects"