### PR TITLE
fix: scroll to top bug on filter tag select

### DIFF
--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -94,7 +94,6 @@ export default {
   },
 
   mounted () {
-    console.log('error layout')
     if (this.$Countly) {
       this.$Countly.trackEvent('404_NOT_FOUND', {
         path: this.$route.path,

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -94,6 +94,7 @@ export default {
   },
 
   mounted () {
+    console.log('error layout')
     if (this.$Countly) {
       this.$Countly.trackEvent('404_NOT_FOUND', {
         path: this.$route.path,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/nuxt-module-ecosystem-directory",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/nuxt-module-ecosystem-directory",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "A Nuxt module that loads all the boilerplate layouts, pages, components, styles, stores and functionality to run the Ecosystem Directory.",
   "keywords": [
     "Nuxt",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -332,12 +332,14 @@ export default {
     collapseSegmentAndFeaturedSliders () {
       if (this.segmentSlider) {
         this.segmentSlider = false
+        this.sectionHeight = 0
+        window.scrollTo(0, 0)
       }
       if (this.featuredSlider) {
         this.featuredSlider = false
+        this.sectionHeight = 0
+        window.scrollTo(0, 0)
       }
-      this.sectionHeight = 0
-      window.scrollTo(0, 0)
     },
     resetSectionHeight () {
       if (this.$refs.collapsibleSection.firstElementChild) {


### PR DESCRIPTION
Fixes a bug where selecting any filter tag would automatically scroll to the top of the page.